### PR TITLE
Added camera usage permissions to the iOS sample app

### DIFF
--- a/sample-app/ios/sample-app/Info.plist
+++ b/sample-app/ios/sample-app/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Card scanning requires camera permissions</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This solves the RN crash when accessing the Scan Camera functionality on iOS