### PR TITLE
Address E2E flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ commands:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "CircleCI has just ran the :aapl: React Native E2E tests, but they failed. Review the failures here: \n *<$CIRCLE_BUILD_URL | :circleci: Open build>*"
+                    "text": "CircleCI has just ran the :aapl: & :android: React Native E2E tests, but they failed. Review the failures here: \n *<$CIRCLE_BUILD_URL | :circleci: Open build>*"
                   }
                 },
                 {
@@ -59,7 +59,7 @@ commands:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "CircleCI has just *successfully* ran the :aapl: React Native E2E tests! \n *<$CIRCLE_BUILD_URL | :circleci: Open build>*"
+                    "text": "CircleCI has just *successfully* ran the :aapl: & :android: React Native E2E tests! \n *<$CIRCLE_BUILD_URL | :circleci: Open build>*"
                   }
                 },
                 {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,10 @@ jobs:
           restore-gradle-cache-prefix: v1a
           post-emulator-launch-assemble-command: 'echo "Emulator is ready"'
       - run:
+          name: Disable gesture navigation
+          command: |
+            adb shell cmd overlay enable com.android.internal.systemui.navbar.threebutton
+      - run:
           name: Run the tests
           working_directory: example
           command: |

--- a/example/e2e/functional.test.ts
+++ b/example/e2e/functional.test.ts
@@ -217,7 +217,7 @@ describe('E2E Functional Tests', () => {
       await device.disableSynchronization();
       await waitFor(element(by.text(Selectors.THREEDS2_TITLE_ANDROID)))
         .toBeVisible()
-        .withTimeout(15000);
+        .withTimeout(30000);
     } else {
       await waitFor(element(by.text(Selectors.THREEDS2_SCREEN_HEADER)))
         .toBeVisible()
@@ -273,6 +273,6 @@ describe('E2E Functional Tests', () => {
     }
     await waitFor(element(by.text(UserFeedback.THREEDS2_CANCELLED)))
       .toExist()
-      .withTimeout(10000);
+      .withTimeout(30000);
   });
 });

--- a/example/e2e/functional.test.ts
+++ b/example/e2e/functional.test.ts
@@ -147,7 +147,7 @@ describe('E2E Functional Tests', () => {
     await assertResultsScreen({ type: '4', result: '1' });
   });
 
-  it.only('should successfully complete a 3DS2 payment transaction via payment methods', async () => {
+  it('should successfully complete a 3DS2 payment transaction via payment methods', async () => {
     await toggleAskForCSCSetting();
     if (await isAndroid()) {
       await device.disableSynchronization();
@@ -157,7 +157,7 @@ describe('E2E Functional Tests', () => {
     await assertResultsScreen({ type: '1', result: '1' });
   });
 
-  it.only('should successfully complete a 3DS2 pre-auth transaction via payment methods', async () => {
+  it('should successfully complete a 3DS2 pre-auth transaction via payment methods', async () => {
     await toggleAskForCSCSetting();
     if (await isAndroid()) {
       await device.disableSynchronization();

--- a/example/e2e/functional.test.ts
+++ b/example/e2e/functional.test.ts
@@ -147,7 +147,7 @@ describe('E2E Functional Tests', () => {
     await assertResultsScreen({ type: '4', result: '1' });
   });
 
-  it('should successfully complete a 3DS2 payment transaction via payment methods', async () => {
+  it.only('should successfully complete a 3DS2 payment transaction via payment methods', async () => {
     await toggleAskForCSCSetting();
     if (await isAndroid()) {
       await device.disableSynchronization();
@@ -157,7 +157,7 @@ describe('E2E Functional Tests', () => {
     await assertResultsScreen({ type: '1', result: '1' });
   });
 
-  it('should successfully complete a 3DS2 pre-auth transaction via payment methods', async () => {
+  it.only('should successfully complete a 3DS2 pre-auth transaction via payment methods', async () => {
     await toggleAskForCSCSetting();
     if (await isAndroid()) {
       await device.disableSynchronization();

--- a/example/e2e/helpers.ts
+++ b/example/e2e/helpers.ts
@@ -27,10 +27,10 @@ export async function fillPaymentDetailsSheet(props: CardDetails) {
       by.id(Selectors.PAY_NOW_BUTTON).and(by.traits(['button']))
     ).tap();
   } else {
-    await element(by.id(Selectors.ANDROID_CARD)).typeText(props.number);
-    await element(by.id(Selectors.ANDROID_NAME)).typeText(props.name);
-    await element(by.id(Selectors.ANDROID_EXPIRY)).typeText(props.expiry);
-    await element(by.id(Selectors.ANDROID_CODE)).typeText(props.code);
+    await element(by.id(Selectors.ANDROID_CARD)).replaceText(props.number);
+    await element(by.id(Selectors.ANDROID_NAME)).replaceText(props.name);
+    await element(by.id(Selectors.ANDROID_EXPIRY)).replaceText(props.expiry);
+    await element(by.id(Selectors.ANDROID_CODE)).replaceText(props.code);
     await element(by.id(Selectors.ANDROID_PAY_NOW)).tap();
     await device.enableSynchronization();
   }

--- a/example/e2e/helpers.ts
+++ b/example/e2e/helpers.ts
@@ -188,7 +188,7 @@ export async function toggleAskForCSCSetting() {
 
 export async function fillSecurityCodeSheet() {
   if (await isAndroid()) {
-    await delay(1500);
+    await delay(5000);
     await element(by.id(Selectors.ANDROID_CODE)).typeText(
       TestData.SECURITY_CODE
     );

--- a/example/e2e/helpers.ts
+++ b/example/e2e/helpers.ts
@@ -103,7 +103,7 @@ export async function addCardPaymentMethodAndPay() {
     code: TestData.SECURITY_CODE,
   });
   if (await isAndroid()) {
-    await delay(2000);
+    await delay(5000);
     await device.disableSynchronization();
     await element(by.id(Selectors.ANDROID_METHODS_PAY_NOW)).tap();
   } else {

--- a/example/e2e/helpers.ts
+++ b/example/e2e/helpers.ts
@@ -27,9 +27,9 @@ export async function fillPaymentDetailsSheet(props: CardDetails) {
       by.id(Selectors.PAY_NOW_BUTTON).and(by.traits(['button']))
     ).tap();
   } else {
-    await element(by.id(Selectors.ANDROID_CARD)).replaceText(props.number);
-    await element(by.id(Selectors.ANDROID_NAME)).replaceText(props.name);
-    await element(by.id(Selectors.ANDROID_EXPIRY)).replaceText(props.expiry);
+    await element(by.id(Selectors.ANDROID_CARD)).typeText(props.number);
+    await element(by.id(Selectors.ANDROID_NAME)).typeText(props.name);
+    await element(by.id(Selectors.ANDROID_EXPIRY)).typeText(props.expiry);
     await element(by.id(Selectors.ANDROID_CODE)).typeText(props.code);
     await element(by.id(Selectors.ANDROID_PAY_NOW)).tap();
     await device.enableSynchronization();
@@ -49,7 +49,7 @@ export async function complete3DS2() {
   if (await isAndroid()) {
     await waitFor(element(by.text(Selectors.THREEDS2_TITLE_ANDROID)))
       .toBeVisible()
-      .withTimeout(15000);
+      .withTimeout(30000);
     await delay(1500);
     try {
       for (let i = 0; i < 3; i++) {
@@ -60,7 +60,7 @@ export async function complete3DS2() {
   } else {
     await waitFor(element(by.text(Selectors.THREEDS2_SCREEN_HEADER)))
       .toBeVisible()
-      .withTimeout(15000);
+      .withTimeout(30000);
     await element(by.text(Selectors.THREEDS2_COMPLETE_BUTTON)).longPress();
     await delay(5000);
     try {

--- a/example/e2e/jest.config.js
+++ b/example/e2e/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   rootDir: '..',
   testMatch: ['<rootDir>/e2e/**/*.test.ts'],
-  testTimeout: 120000,
+  testTimeout: 300000,
   maxWorkers: 1,
   globalSetup: 'detox/runners/jest/globalSetup',
   globalTeardown: 'detox/runners/jest/globalTeardown',


### PR DESCRIPTION
* Increase a few timeouts due to painfully slow emulators on Linux box
* Disable gesture navigation to prevent issues when scrolling
* Use `replaceText` instead of `typeText` for speed
* Android runs approx 25 mins, iOS 17 mins - longer than I'd like but stability over speed, failures should catch actual bugs