### PR TITLE
chore(example-app): clears out unimplemented Apple Pay Recurring Paym. properties

### DIFF
--- a/example/e2e/configs/billingInfo.json
+++ b/example/e2e/configs/billingInfo.json
@@ -99,17 +99,7 @@
         "intervalUnit": "",
         "intervalCount": ""
       },
-      "trialBilling": {
-        "isOn": false,
-        "label": "",
-        "amount": "",
-        "startDate": "",
-        "endDate": "",
-        "intervalUnit": "",
-        "intervalCount": ""
-      },
-      "billingAgreement": "",
-      "tokenNotificationURL": ""
+      "billingAgreement": ""
     }
   },
   "googlePay": {

--- a/example/e2e/configs/default.json
+++ b/example/e2e/configs/default.json
@@ -99,17 +99,7 @@
         "intervalUnit": "",
         "intervalCount": ""
       },
-      "trialBilling": {
-        "isOn": false,
-        "label": "",
-        "amount": "",
-        "startDate": "",
-        "endDate": "",
-        "intervalUnit": "",
-        "intervalCount": ""
-      },
-      "billingAgreement": "",
-      "tokenNotificationURL": ""
+      "billingAgreement": ""
     }
   },
   "googlePay": {

--- a/example/e2e/configs/noPreferenceCRI.json
+++ b/example/e2e/configs/noPreferenceCRI.json
@@ -99,17 +99,7 @@
         "intervalUnit": "",
         "intervalCount": ""
       },
-      "trialBilling": {
-        "isOn": false,
-        "label": "",
-        "amount": "",
-        "startDate": "",
-        "endDate": "",
-        "intervalUnit": "",
-        "intervalCount": ""
-      },
-      "billingAgreement": "",
-      "tokenNotificationURL": ""
+      "billingAgreement": ""
     }
   },
   "googlePay": {

--- a/example/e2e/configs/ravelin.json
+++ b/example/e2e/configs/ravelin.json
@@ -99,17 +99,7 @@
         "intervalUnit": "",
         "intervalCount": ""
       },
-      "trialBilling": {
-        "isOn": false,
-        "label": "",
-        "amount": "",
-        "startDate": "",
-        "endDate": "",
-        "intervalUnit": "",
-        "intervalCount": ""
-      },
-      "billingAgreement": "",
-      "tokenNotificationURL": ""
+      "billingAgreement": ""
     }
   },
   "googlePay": {

--- a/example/src/Data/Constants/index.tsx
+++ b/example/src/Data/Constants/index.tsx
@@ -104,17 +104,7 @@ export const DEFAULT_SETTINGS_DATA: SettingsData = {
         intervalUnit: '',
         intervalCount: '',
       },
-      trialBilling: {
-        isOn: false,
-        label: '',
-        amount: '',
-        startDate: '',
-        endDate: '',
-        intervalUnit: '',
-        intervalCount: '',
-      },
       billingAgreement: '',
-      tokenNotificationURL: '',
     },
   },
   googlePay: {

--- a/example/src/Data/Mapping/index.ts
+++ b/example/src/Data/Mapping/index.ts
@@ -597,16 +597,11 @@ export const judoConfigurationFromSettingsData = ({
   const {
     isOn: recurringPaymentRequestIsOn = false,
     regularBilling = {} as Record<string, any>,
-    trialBilling = {} as Record<string, any>,
   } = recurringPaymentRequest || {};
 
   if (recurringPaymentRequestIsOn) {
-    const {
-      paymentDescription,
-      managementURL,
-      billingAgreement,
-      tokenNotificationURL,
-    } = recurringPaymentRequest;
+    const { paymentDescription, managementURL, billingAgreement } =
+      recurringPaymentRequest;
 
     const {
       isOn: regularBillingIsOn = false,
@@ -617,16 +612,6 @@ export const judoConfigurationFromSettingsData = ({
       intervalUnit: regularBillingIntervalUnit,
       intervalCount: regularBillingIntervalCount,
     } = regularBilling;
-
-    const {
-      isOn: trialBillingIsOn = false,
-      label: trialBillingLabel,
-      amount: trialBillingAmount,
-      startDate: trialBillingStartDate,
-      endDate: trialBillingEndDate,
-      intervalUnit: trialBillingIntervalUnit,
-      intervalCount: trialBillingIntervalCount,
-    } = trialBilling;
 
     const intervalUnit = (intervalUnitString: string) => {
       switch (intervalUnitString) {
@@ -656,7 +641,6 @@ export const judoConfigurationFromSettingsData = ({
       // @ts-ignore
       managementURL: managementURL || undefined,
       billingAgreement: billingAgreement || undefined,
-      tokenNotificationURL: tokenNotificationURL || undefined,
       // @ts-ignore
       regularBilling: regularBillingIsOn
         ? {
@@ -667,18 +651,6 @@ export const judoConfigurationFromSettingsData = ({
             intervalUnit: intervalUnit(regularBillingIntervalUnit),
             intervalCount: regularBillingIntervalCount
               ? Number(regularBillingIntervalCount)
-              : undefined,
-          }
-        : undefined,
-      trialBilling: trialBillingIsOn
-        ? {
-            label: trialBillingLabel,
-            amount: trialBillingAmount,
-            startDate: trialBillingStartDate,
-            endDate: trialBillingEndDate,
-            intervalUnit: intervalUnit(trialBillingIntervalUnit),
-            intervalCount: trialBillingIntervalCount
-              ? Number(trialBillingIntervalCount)
               : undefined,
           }
         : undefined,

--- a/example/src/Data/SettingsSections/applePayRecurringPaymentSection.ts
+++ b/example/src/Data/SettingsSections/applePayRecurringPaymentSection.ts
@@ -22,8 +22,6 @@ const applePayRecurringPaymentSection = (
   const managementURLPath = 'applePay.recurringPaymentRequest.managementURL';
   const billingAgreementPath =
     'applePay.recurringPaymentRequest.billingAgreement';
-  const tokenNotificationURLPath =
-    'applePay.recurringPaymentRequest.tokenNotificationURL';
 
   const isRegularBillingOnPath =
     'applePay.recurringPaymentRequest.regularBilling.isOn';
@@ -40,22 +38,6 @@ const applePayRecurringPaymentSection = (
     'applePay.recurringPaymentRequest.regularBilling.intervalUnit';
   const regularBillingIntervalCountPath =
     'applePay.recurringPaymentRequest.regularBilling.intervalCount';
-
-  const isTrialBillingOnPath =
-    'applePay.recurringPaymentRequest.trialBilling.isOn';
-  const isTrialBillingOn = _.get(data, isTrialBillingOnPath);
-  const trialBillingLabelPath =
-    'applePay.recurringPaymentRequest.trialBilling.label';
-  const trialBillingAmountPath =
-    'applePay.recurringPaymentRequest.trialBilling.amount';
-  const trialBillingStartDatePath =
-    'applePay.recurringPaymentRequest.trialBilling.startDate';
-  const trialBillingEndDatePath =
-    'applePay.recurringPaymentRequest.trialBilling.endDate';
-  const trialBillingIntervalUnitPath =
-    'applePay.recurringPaymentRequest.trialBilling.intervalUnit';
-  const trialBillingIntervalCountPath =
-    'applePay.recurringPaymentRequest.trialBilling.intervalCount';
 
   const regularBillingConfiguration = [
     {
@@ -112,61 +94,6 @@ const applePayRecurringPaymentSection = (
       : []),
   ];
 
-  const trialBillingConfiguration = [
-    {
-      path: 'trialBilling',
-      dataType: SettingsItemDataType.SECTION_SEPARATOR,
-      title: 'TRIAL BILLING',
-    },
-    {
-      path: isTrialBillingOnPath,
-      dataType: SettingsItemDataType.BOOLEAN,
-      title: 'Enable trial billing item',
-      value: isTrialBillingOn,
-    },
-    ...(isTrialBillingOn
-      ? [
-          {
-            path: trialBillingLabelPath,
-            dataType: SettingsItemDataType.TEXT,
-            title: 'Label',
-            value: _.get(data, trialBillingLabelPath),
-          },
-          {
-            path: trialBillingAmountPath,
-            dataType: SettingsItemDataType.TEXT,
-            title: 'Amount',
-            value: _.get(data, trialBillingAmountPath),
-          },
-          {
-            path: trialBillingStartDatePath,
-            dataType: SettingsItemDataType.TEXT,
-            title: 'Start date',
-            value: _.get(data, trialBillingStartDatePath),
-          },
-          {
-            path: trialBillingEndDatePath,
-            dataType: SettingsItemDataType.TEXT,
-            title: 'End date',
-            value: _.get(data, trialBillingEndDatePath),
-          },
-          {
-            path: trialBillingIntervalUnitPath,
-            dataType: SettingsItemDataType.SINGLE_SELECTION,
-            title: 'Interval unit',
-            value: _.get(data, trialBillingIntervalUnitPath),
-            options: INTERVAL_UNIT_OPTIONS,
-          },
-          {
-            path: trialBillingIntervalCountPath,
-            dataType: SettingsItemDataType.TEXT,
-            title: 'Interval count',
-            value: _.get(data, trialBillingIntervalCountPath),
-          },
-        ]
-      : []),
-  ];
-
   return {
     header: 'APPLE PAY RECURRING PAYMENT',
     data: [
@@ -196,14 +123,7 @@ const applePayRecurringPaymentSection = (
               title: 'Billing agreement',
               value: _.get(data, billingAgreementPath),
             },
-            {
-              path: tokenNotificationURLPath,
-              dataType: SettingsItemDataType.TEXT,
-              title: 'Token notification URL',
-              value: _.get(data, tokenNotificationURLPath),
-            },
             ...regularBillingConfiguration,
-            ...trialBillingConfiguration,
           ]
         : []),
     ],

--- a/example/src/Data/TypeDefinitions/index.ts
+++ b/example/src/Data/TypeDefinitions/index.ts
@@ -103,17 +103,7 @@ export interface SettingsData {
         intervalUnit: string;
         intervalCount: string;
       };
-      trialBilling: {
-        isOn: boolean;
-        label: string;
-        amount: string;
-        startDate: string;
-        endDate: string;
-        intervalUnit: string;
-        intervalCount: string;
-      };
       billingAgreement: string;
-      tokenNotificationURL: string;
     };
   };
   googlePay: {

--- a/src/types/judo-apple-pay-configuration.ts
+++ b/src/types/judo-apple-pay-configuration.ts
@@ -66,8 +66,14 @@ export interface JudoApplePayRecurringPaymentRequest {
   paymentDescription: string;
   managementURL: string;
   regularBilling: JudoRecurringPaymentSummaryItem;
+  /**
+   * Reserved for future use. Currently not implemented.
+   */
   trialBilling?: JudoRecurringPaymentSummaryItem;
   billingAgreement?: string;
+  /**
+   * Reserved for future use. Currently not implemented.
+   */
   tokenNotificationURL?: string;
 }
 


### PR DESCRIPTION
1. Usages of unimplemented trialBilling and tokenNotificationUrl have been removed from exemplary RN apps.

2. Unused properties have been enhanced with a comment indicating this fact to potential developers implementing Judo Apple Pay Recurring Payments.
